### PR TITLE
外部キーのgroup_idをnullableに変更

### DIFF
--- a/database/migrations/2024_02_09_123557_add_foreign_keys_to_tables.php
+++ b/database/migrations/2024_02_09_123557_add_foreign_keys_to_tables.php
@@ -12,8 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->foreignId('group_id')->constrained('groups');
-        });
+            $table->foreignId('group_id')->nullable()->constrained('groups');
+        });        
         Schema::table('events', function (Blueprint $table) {
             $table->foreignId('user_id')->constrained('users');
             $table->foreignId('tag_id')->constrained('tags');


### PR DESCRIPTION
## チケットへのリンク


## やったこと
2024_02_09_123557_add_foreign_keys_to_tables.phpのgroup_idをnullableに変更

## やってないこと


## レビュー対象画面のURL


## 動作確認


## 備考

